### PR TITLE
Addition of multiple pages for ACSAI

### DIFF
--- a/30786/docs/exams.md
+++ b/30786/docs/exams.md
@@ -1,0 +1,222 @@
+---
+title: Exams
+weight: 3
+---
+
+# Exams
+
+As every university, Sapienza asks its students to partake to the exams related to the courses that the students followed during the lecture semesters. Usually, exams are held during the exam sessions (check them [here](../Courses%20&%20Calendar/)).
+
+An exam session is a time period of 7/8 weeks in which professors allow their students to take the exams related to their subject. Except for the exam session of September and the extraordinary sessions (find more about it [here](https://www.uniroma1.it/it/content/esami-di-profitto)), all the sessions allow the students to take the exam up to two times.
+
+You can sit for an exam as many times you want, and there is no penalty for that, **as long as you haven't accepted your grade**.
+
+{{< hint info >}}
+**Q&A: When can I sit for an exam?**
+
+Assume that you want to take the exam of Linear Algebra. You just started the course in the A.Y. 2024/25. The professor will communicate two dates on which you will be able to take the exam, (say for instance the 10/1/2025 and the 3/2/2025). You can take the exam either on the first or in the second date.
+
+Suppose that, for any reason, you can't take it in the first exam session (so in the winter one): you will be able to sit for that exam in **any other** exam session to which you are allowed to participate (so either in the summer or September session, unless you made request for the extraordinary sessions. More info regarding them can be found below) **until you pass the exam**.
+{{< /hint >}}
+
+## Types of exams
+
+There are many types of exams, and they mostly depend on the subject that you do: some may be **oral** (which consist in a discussion with the professor over the topics studied in the course), some may be **written** (which could consist on a theoretical exam or a practical one), others may be **practical** (for instance if you have to make a project), and some may blend these modes together.
+
+Some exams may ask you to first take a written exam and then an oral one (if you pass a certain grade threshold, if you pass the written one, etc...). It all depends on the professor, there is no common rule.
+
+Mind that each professor has its own way to do an exam, so **pay attention** to the modalities that will be explained at the beginning and at the end of the course. Most importantly, **before asking to the professor** for something that it may have already said, check the course page on Moodle / Classroom / whichever platform first, or ask your colleagues eventually.
+
+You will be able to find more information regarding which kind of exams you'll find in each course page.
+
+## How to book an exam
+
+In order to reserve an exam, you must do it through **Infostud**, the official student platform made by Sapienza. You can find Infostud by going to the official Sapienza website ([uniroma1.it](https://www.uniroma1.it)) and navigating to the `Studenti`/`Students` section. There, you'll find two versions of Infostud: `Desktop` and `Mobile`. They both allow you to do the same things. If you are on a computer, you can freely open both versions, since they are responsive for desktops. If you are on a mobile, consider opening the mobile version, since is adapted for small, vertical devices.
+
+{{< columns >}}
+
+1. Go to the [uniroma1.it](https://www.uniroma1.it) website, and click on the `Studenti`/`Students` section;
+<br><br>
+2. Choose if you want to open the `Desktop` or `Mobile` version of Infostud. Depending on the one that you choose, click on the corresponding tab here below;
+<br><br>
+3. After clicking on any of the two versions of Infostud, you'll be brought to the SSO page for accessing any Sapienza service. There will be 3 options for logging in:
+    - **Matricola**: you will be able to log in with your matricola and password;
+    - **SPID**: log in through your SPID method;
+    - **CIE**: log in with your Carta d'Identità (**CI**), the italian ID card.
+
+{{< hint warning >}}
+**Warning**
+
+If you are italian or you have an italian CI, then **you must log in** with either the **SPID** or the **CIE** method.
+
+The italian CI is not the same of the "Permesso di Soggiorno" (**PdS**, from here on) (the Staying Permit): if you have the PdS then you can access through your matricola.
+{{< /hint >}}
+
+<--->
+
+<img src="https://i.imgur.com/5d9TxZN.png">
+<p style="font-size: 8pt">Step 1: homepage of Sapienza's website</p>
+<br>
+
+<img src="https://i.imgur.com/kcmhsej.png">
+<p style="font-size: 8pt">Step 2: <code>Studenti</code>/<code>Students</code> webpage</p>
+<br>
+
+<img src="https://i.imgur.com/JB10ioP.png">
+<p style="font-size: 8pt">Step 3: unified SSO page, with the three login options</p>
+
+{{< /columns >}}
+
+Now, depending on the platform that you chose at step 2, the procedure may vary slightly. Here we show the procedure for both platforms:
+
+{{< tabs "uniqueid" >}}
+{{< tab "🖥 Infostud Desktop" >}}
+
+4. If you chose to open Infostud Desktop, you'll see a screen with 8 tiles, one of which being `Corsi di Laurea`/`Bachelors and Masters Degree Programmes` (CdL): click on that tile, and a new page will open up;
+
+<img src="https://i.imgur.com/ihPbgXF.png">
+<p style="font-size: 8pt">Step 4: InfoStud Desktop home</p>
+
+5. Go down on the sidebar, until you find the `Esami`/`Exams` section. Under that section, click on the `Prenota esami`/`Book exams` menu: you will be sent to another page;
+
+<img src="https://i.imgur.com/3lRDDrS.png">
+<p style="font-size: 8pt">Step 5: Select the <code>Prenota esami</code>/<code>Book exams</code> menu</p>
+
+6. You'll now see a list of all the exams that you can book. Let's say that you want to book a seat for the next date of the "*AI Lab: Computer Vision and NLP*" course. In order to book a seat, you just have to press the `Appelli`/`Exam sessions` button. You will be brought to a page with all the possible seats;
+
+<img src="https://i.imgur.com/zdxv11g.png">
+<p style="font-size: 8pt">Step 6: Select the exam that you want to book</p>
+
+7. Finally, choose the date that you want to book. On the corresponding date, select from the `Modalità di svolgimento` menu the voice `IN PRESENZA`, and finally click on `Prenota`/`Book`. If all went well, you will receive an email notification on your institutional email with the receipt of the exam, confirming that the booking was successful.
+
+<img src="https://i.imgur.com/t6q8qjx.png">
+<p style="font-size: 8pt">Step 7: Select the date that you want to book and choose the exam modality (the only possible option should be <code>IN PRESENZA</code>)<br>Step 8: Finally press on the <code>Book</code> button</p>
+
+{{< hint warning >}}
+**Warning**
+
+If you can't book for an exam date, check whether the reservation period opened or not. You can check it under the `Inizio prenotazione`/`Opening date for booking` column.
+{{< /hint>}}
+
+{{< /tab >}}
+{{< tab "📱 Infostud Mobile" >}}
+
+4. If you chose to open InfoStud Mobile, you'll see various buttons. You should click on the uppermost one, which says `[...] Prenota ora`/`[...] Book now`. You will be brought to another page;
+
+<img src="https://i.imgur.com/j5oflvJ.png">
+<p style="font-size: 8pt">Step 4: InfoStud Mobile home</p>
+
+5. You'll now see a list of all the exams that you can book. Let's say that you want to book a seat for the next date of the "*AI Lab: Computer Vision and NLP*" course. In order to book a seat, you just have to click on the checkmark on the top-right corner of the exam row. Once you do that, you'll see that the checkmark becomes black. Now click on `Mostra appelli`/`Show Exam Sessions`. You will be brought to a page with all the possible seats;
+
+{{< columns >}}
+
+<img src="https://i.imgur.com/4gKhvxS.png">
+
+<--->
+
+<img src="https://i.imgur.com/UrKoVO3.png">
+
+{{< /columns >}}
+<p style="font-size: 8pt">Step 5: Select the exam that you want to book through the checkmark, and then click on <code>Mostra appelli</code>/<code>Show Exam Sessions</code></p>
+
+6. Finally, choose the date that you want to book. On the corresponding date, select first the checkmark on the top-right corner. After that, a pop-up will show on the bottom of the page. There, select from the attendance mode menu the voice `In presenza`, and finally click on `Continua`/`Continue`. If all went well, you will receive an email notification on your institutional email with the receipt of the exam, confirming that the booking was successful.
+
+<img src="https://i.imgur.com/4jQtWVj.png"> 
+<p style="font-size: 8pt">Step 6: Select the date that you want to book and choose the exam modality. After that, click on <code>Continua</code>/<code>Continue</code></p>
+
+{{< hint warning >}}
+**Warning**
+
+If you can't book for an exam date, check whether the reservation period opened or not. You can check it by expanding the exam notes: on the before-last row there will be the row `Prenotazioni da DD/MM/YYYY a DD/MM/YYYY`/`Bookings from DD/MM/YYYY to DD/MM/YYYY`.
+{{< /hint>}}
+
+{{< /tab >}}
+{{< /tabs >}}
+
+{{< hint info >}}
+**Q&A: InfoStud tells me that I have to complete the OPIS first. What do I do?**
+
+If you didn't complete the OPIS before through a code that your professor shared in class, you will be asked to complete it. Once you'll do the OPIS, just repeat the procedures to book the exam. More infos about the OPIS can be found [here](../opis).
+{{< /hint >}}
+
+## FAQ
+
+{{< details "Where can I see all the exams to which I registered?">}}
+
+You can see the exams to which you registered within InfoStud.
+- In the **desktop version**, there is a section called `Esami prenotati`/`Booked exams`, which is right below the `Prenota esami`/`Book exams` menu. There, you'll find all the exams that you booked for.
+
+<img src="https://i.imgur.com/GLZ6y5I.png">
+
+- In the **mobile version**, you'll find them in the same page where you can book the exams. They will appear on the top of the page with a yellow bar instead of a beige one.
+
+<img src="https://i.imgur.com/U859JCp.png">
+
+{{< /details >}}
+<br>
+{{< details "How can I delete a reservation for an exam?">}}
+
+- In the **desktop version**, you can delete a booking by searching it first in the `Esami prenotati`/`Booked exams` menu, and then by pressing the `Cancella`/`Delete` button.
+
+<img src="https://i.imgur.com/kQFvSEu.png">
+
+- In the **mobile version**, you can delete an exam by searching it first among the booked exams, then pressing the downwards arrow on the corresponding exam and finally pressing the trashcan glyph.
+
+<img src="https://i.imgur.com/XLQPej4.png">
+
+{{< /details >}}
+<br>
+{{< details "Once an exam ends, where and when can I see my grade?">}}
+
+to-do
+
+{{< /details >}}
+<br>
+{{< details "Where can I see my grades?">}}
+
+to-do
+
+{{< /details >}}
+<br>
+{{< details "How do I accept or refuse a grade?">}}
+
+to-do
+
+{{< /details >}}
+<br>
+{{< details "Is there any penalty for refusing a grade?">}}
+
+to-do
+
+{{< /details >}}
+<br>
+{{< details "I successfully passed an exam, but I don't see my grade. Why can't I see it?">}}
+
+to-do
+
+{{< /details >}}
+<br>
+{{< details "What's the difference between a registered and a non-registered grade?">}}
+
+to-do
+
+{{< /details >}}
+<br>
+{{< details "I scored 30 cum laude in an exam, but I don't see the laude on InfoStud. Why?">}}
+
+to-do
+
+{{< /details >}}
+
+## Terminology
+
+|Term|Meaning|
+|---|---|
+|InfoStud|Official Sapienza's students' platform|
+|CI|Carta d'Identità|
+|SPID|Sistema Pubblico d'Identità Generale, one of the two possible official authentication methods for Italy's PA services (with the other being CIE)|
+|CIE|Carta d'Identità Elettronica, the second possible official authentication method for Italy's PA services. Uses the CI and your smartphone, if said smartphone can read NFC tags|
+|PA|Public Administration|
+|PdS|Permesso di Soggiorno (Staying Permit)|
+|CdL|Corsi di Laurea (Bachelor Programmes)|
+|OPIS|Student's Opinions survey|

--- a/30786/docs/getting-in/_index.md
+++ b/30786/docs/getting-in/_index.md
@@ -1,0 +1,5 @@
+---
+title: Getting in ACSAI
+bookCollapseSection: true
+weight: 1
+---

--- a/30786/docs/getting-in/admission-process.md
+++ b/30786/docs/getting-in/admission-process.md
@@ -1,0 +1,5 @@
+---
+title: Admission process
+---
+
+# Admission process

--- a/30786/docs/opis.md
+++ b/30786/docs/opis.md
@@ -1,0 +1,21 @@
+---
+title: Student's Opinions (OPIS)
+weight: 2
+---
+# Student's Opinions (OPIS)
+
+The **student's opinions** (**OPIS**) are **anonymous surveys** over the quality of the teaching for each subject. They are **mandatory** for booking exams for a specific subject, and are analysed each year by a board of professors, which will use them for identifying problems and find solutions for them.
+
+Each OPIS can be completed on InfoStud, by inserting an 8-characters (letters or numbers) string in the format `XXXXXXXX` (for instance, `MPDSXZSH` could be a plausible OPIS code). Mind that the OPIS for a certain subject can be completed **once per academic year**. Until the moment when it's not sent, all the data are saved as draft, and will be sent to Sapienza only when the student finishes the whole questionnaire.
+
+## Structure of an OPIS survey
+
+An OPIS survey is made of 7 sections, 6 of which are made of questions with multiple choice answers. The possible answers are:
+ - Definitely yes;
+ - More yes than no;
+ - More no than yes;
+ - Definitely not.
+
+The last section contains two text sections for leaving any comment that you have, for a maximum of 300 characters.
+
+## How to complete an OPIS survey

--- a/30786/news/_index.md
+++ b/30786/news/_index.md
@@ -1,0 +1,39 @@
+---
+title: 📰 News
+bookFlatSection: true
+weight: 1
+---
+
+# News
+
+Here you can find some news regarding the ACSAI course and the most important information. Check it out!
+
+## Recent news
+
+{{< columns >}}
+
+{{< hint info >}}
+
+## Dates for the A.Y. 2024/25
+<p style="font-size: 10pt"><i>27/6/2024</i></p>
+ 
+The new dates of our department have been just published! Check them out [at this link](../courses--calendar/calendar/).
+
+TLDR:
+ - the first semester's lectures will start the **23/9/2024** and will end the **20/12/2024**;
+ - the first exam session will start the **7/1/2025** and will end the **25/2/2025**.
+
+{{< /hint >}}
+
+<--->
+
+{{< hint info >}}
+
+## New tutors assigned
+<p style="font-size: 10pt"><i>27/6/2024</i></p>
+ 
+The new tutors have been assigned for the A.Y. 2024/25. Soon, a list with their contacts will be published
+
+{{</ hint >}}
+
+{{</ columns >}}

--- a/30786/resources/First Year/First Semester/Calculus (Unit 1).md
+++ b/30786/resources/First Year/First Semester/Calculus (Unit 1).md
@@ -1,0 +1,5 @@
+---
+title: Calculus (Unit 1)
+---
+
+# Calculus (Unit 1)

--- a/30786/resources/First Year/First Semester/Computer Architecture (Unit 1).md
+++ b/30786/resources/First Year/First Semester/Computer Architecture (Unit 1).md
@@ -1,0 +1,61 @@
+---
+title: Computer Architecture (Unit 1)
+---
+
+# Computer Architecture (Unit 1)
+
+> "*The course aims to teach how to design combinational and sequential circuits and to make students understand the principles used to design modern computers. In particular, the course deals with the internal structure of the microprocessor and the ideas that have allowed the extraordinary evolution of computing power over the last 30 years, such as pipelining, caching, branch prediction, and multi-processing.*"
+
+|👨‍🏫 Taught by...|✉️ Contacts & Office|🖥 Platform|
+|---|---|---|
+|Daniele De Sensi (Professor)|`desensi@di.uniroma1.it`|Moodle / eLearning|
+|Name Surname (Tutor)|`tutors@email.com`||
+
+## Syllabus
+
+- **Numerical systems**: binary and hexadecimal numerical systems, operations on binary numbers
+- **Combinational Logic Design**: logic gates, Boolean algebra, Karnaugh maps, combinational building blocks, timing
+- **Sequential Logic Design**: Latches and FlipFlops, synchronous logic design, Finite State Machines, timing of sequential logic
+- **Hardware Description Languages** (**HDLs**): combinatorial logic, sequential logic, Finite State Machines, system Verilog, VHDL
+- **Digital Building Blocks**: arithmetic circuits, sequential building blocks, memory arrays, logic arrays
+
+## Suggested books
+
+Harris, S., & Harris, D. (2015). *Digital Design and Computer Architecture: ARM Edition*. Morgan Kaufmann Publishers Inc. (ISBN: 978-0-12-800056-4)
+
+## Exam dates & info
+
+ - **Exam type**: written part + oral part;
+    - **Written part**: lasts for 2:00h, for a maximum of 30 points. Is a practical exam with exercises over the whole program. **Must be passed with at least 18** in order to access to the oral;
+    - **Oral part**: an oral exam over the theory explained in the course. It can increase or decrease the grade, depending on the performance. **Must be passed with at least 18** as final grade.
+
+{{< hint info >}}
+This exam **won't be registered** immediately on InfoStud. In order to be registered, you will have to pass also [Computer Architecture Unit 2](../../second-semester/comparch_u2/). Once you'll pass both exams, the final grade will be computed. Such grade is computed as follows:
+$$
+\text{Final Grade} = \Bigg\lceil \frac{\text{Grade Unit 1} + \text{Grade Unit 2}}{2} \Bigg\rceil
+$$
+<br>
+<br>
+Here follow two examples:
+{{< columns >}}
+If you got 28 for Unit 1 and 30 for Unit 2, the final grade will be
+$$
+\Bigg\lceil \frac{28 + 30}{2} \Bigg\rceil = 29
+$$
+
+<--->
+
+If you got 27 for Unit 1 and 30 for Unit 2, the final grade will be
+$$
+\Bigg\lceil \frac{27 + 30}{2} \Bigg\rceil = \lceil 28.5 \rceil = 29
+$$
+
+{{< /columns >}}
+
+{{< /hint >}}
+
+{{< hint warning >}}
+**Warning**
+
+The exam dates will be here published as soon as the department will comunicate the new dates. We expect to see the new dates around October/November 2024
+{{< /hint >}}

--- a/30786/resources/First Year/First Semester/Linear Algebra.md
+++ b/30786/resources/First Year/First Semester/Linear Algebra.md
@@ -1,0 +1,5 @@
+---
+title: Linear Algebra
+---
+
+# Linear Algebra

--- a/30786/resources/First Year/First Semester/Programming.md
+++ b/30786/resources/First Year/First Semester/Programming.md
@@ -1,0 +1,5 @@
+---
+title: Programming
+---
+
+# Programming (Unit 1 & 2)

--- a/30786/resources/First Year/First Semester/_index.md
+++ b/30786/resources/First Year/First Semester/_index.md
@@ -1,0 +1,3 @@
+---
+bookCollapseSection: true
+---

--- a/30786/resources/First Year/Second Semester/Algorithms.md
+++ b/30786/resources/First Year/Second Semester/Algorithms.md
@@ -1,0 +1,5 @@
+---
+title: Algorithms
+---
+
+# Algorithms

--- a/30786/resources/First Year/Second Semester/Calculus (Unit 2).md
+++ b/30786/resources/First Year/Second Semester/Calculus (Unit 2).md
@@ -1,0 +1,5 @@
+---
+title: Calculus (Unit 2)
+---
+
+# Calculus (Unit 2)

--- a/30786/resources/First Year/Second Semester/Computer Architecture (Unit 2).md
+++ b/30786/resources/First Year/Second Semester/Computer Architecture (Unit 2).md
@@ -1,0 +1,5 @@
+---
+title: Computer Architecture (Unit 2)
+---
+
+# Computer Architecture (Unit 2)

--- a/30786/resources/First Year/Second Semester/Physics.md
+++ b/30786/resources/First Year/Second Semester/Physics.md
@@ -1,0 +1,5 @@
+---
+title: Physics
+---
+
+# Physics

--- a/30786/resources/First Year/Second Semester/Programming 2.md
+++ b/30786/resources/First Year/Second Semester/Programming 2.md
@@ -1,0 +1,5 @@
+---
+title: Programming 2
+---
+
+# Programming 2

--- a/30786/resources/First Year/Second Semester/_index.md
+++ b/30786/resources/First Year/Second Semester/_index.md
@@ -1,0 +1,3 @@
+---
+bookCollapseSection: true
+---

--- a/30786/resources/First Year/_index.md
+++ b/30786/resources/First Year/_index.md
@@ -1,0 +1,4 @@
+---
+bookCollapseSection: true
+weight: 1
+---

--- a/30786/resources/First Year/timetable.md
+++ b/30786/resources/First Year/timetable.md
@@ -1,0 +1,234 @@
+---
+title: Timetable
+weight: 1
+---
+
+# First Year Calendar
+
+{{< hint warning >}}
+**Warning**
+
+The calendar may be subtle to variations until the first week of lectures. Some courses are, in fact, not yet assigned to a specific professor. Check when the last page was not updated in order to avoid confusion
+{{< /hint >}}
+
+## First Semester
+
+<table>
+    <tr align="center">
+        <th rowspan=2>Hour</th>
+        <th colspan=5>Day of the week</th>
+    </tr>
+    <tr align="center">
+        <td><b>Monday</b></td>
+        <td><b>Tuesday</b></td>
+        <td><b>Wednesday</b></td>
+        <td><b>Thursday</b></td>
+        <td><b>Friday</b></td>
+    </tr>
+    <tr align="center">
+        <td>8:00</td>
+        <td rowspan=2>Statistics<br><p style="font-size: 9pt">8:30-10:00<br>Online</p></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>9:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>10:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>11:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>12:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>13:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>14:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>15:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>16:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>17:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>18:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>19:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+</table>
+
+## Second Semester
+
+<table>
+    <tr align="center">
+        <th rowspan=2>Hour</th>
+        <th colspan=5>Day of the week</th>
+    </tr>
+    <tr align="center">
+        <td><b>Monday</b></td>
+        <td><b>Tuesday</b></td>
+        <td><b>Wednesday</b></td>
+        <td><b>Thursday</b></td>
+        <td><b>Friday</b></td>
+    </tr>
+    <tr align="center">
+        <td>8:00</td>
+        <td rowspan=2>Statistics<br><p style="font-size: 9pt">8:30-10:00<br>Online</p></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>9:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>10:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>11:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>12:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>13:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>14:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>15:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>16:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>17:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>18:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>19:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+</table>

--- a/30786/resources/Second Year/_index.md
+++ b/30786/resources/Second Year/_index.md
@@ -1,0 +1,4 @@
+---
+bookCollapseSection: true
+weight: 2
+---

--- a/30786/resources/Second Year/timetable.md
+++ b/30786/resources/Second Year/timetable.md
@@ -1,0 +1,234 @@
+---
+title: Timetable
+weight: 1
+---
+
+# Second Year Calendar
+
+{{< hint warning >}}
+**Warning**
+
+The calendar may be subtle to variations until the first week of lectures. Some courses are, in fact, not yet assigned to a specific professor. Check when the last page was not updated in order to avoid confusion
+{{< /hint >}}
+
+## First Semester
+
+<table>
+    <tr align="center">
+        <th rowspan=2>Hour</th>
+        <th colspan=5>Day of the week</th>
+    </tr>
+    <tr align="center">
+        <td><b>Monday</b></td>
+        <td><b>Tuesday</b></td>
+        <td><b>Wednesday</b></td>
+        <td><b>Thursday</b></td>
+        <td><b>Friday</b></td>
+    </tr>
+    <tr align="center">
+        <td>8:00</td>
+        <td rowspan=2>Statistics<br><p style="font-size: 9pt">8:30-10:00<br>Online</p></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>9:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>10:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>11:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>12:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>13:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>14:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>15:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>16:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>17:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>18:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>19:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+</table>
+
+## Second Semester
+
+<table>
+    <tr align="center">
+        <th rowspan=2>Hour</th>
+        <th colspan=5>Day of the week</th>
+    </tr>
+    <tr align="center">
+        <td><b>Monday</b></td>
+        <td><b>Tuesday</b></td>
+        <td><b>Wednesday</b></td>
+        <td><b>Thursday</b></td>
+        <td><b>Friday</b></td>
+    </tr>
+    <tr align="center">
+        <td>8:00</td>
+        <td rowspan=2>Statistics<br><p style="font-size: 9pt">8:30-10:00<br>Online</p></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>9:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>10:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>11:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>12:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>13:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>14:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>15:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>16:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>17:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>18:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>19:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+</table>

--- a/30786/resources/Third Year/_index.md
+++ b/30786/resources/Third Year/_index.md
@@ -1,0 +1,4 @@
+---
+bookCollapseSection: true
+weight: 3
+---

--- a/30786/resources/Third Year/timetable.md
+++ b/30786/resources/Third Year/timetable.md
@@ -1,0 +1,234 @@
+---
+title: Timetable
+weight: 1
+---
+
+# Third Year Calendar
+
+{{< hint warning >}}
+**Warning**
+
+The calendar may be subtle to variations until the first week of lectures. Some courses are, in fact, not yet assigned to a specific professor. Check when the last page was not updated in order to avoid confusion
+{{< /hint >}}
+
+## First Semester
+
+<table>
+    <tr align="center">
+        <th rowspan=2>Hour</th>
+        <th colspan=5>Day of the week</th>
+    </tr>
+    <tr align="center">
+        <td><b>Monday</b></td>
+        <td><b>Tuesday</b></td>
+        <td><b>Wednesday</b></td>
+        <td><b>Thursday</b></td>
+        <td><b>Friday</b></td>
+    </tr>
+    <tr align="center">
+        <td>8:00</td>
+        <td rowspan=2>Statistics<br><p style="font-size: 9pt">8:30-10:00<br>Online</p></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>9:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>10:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>11:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>12:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>13:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>14:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>15:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>16:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>17:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>18:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>19:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+</table>
+
+## Second Semester
+
+<table>
+    <tr align="center">
+        <th rowspan=2>Hour</th>
+        <th colspan=5>Day of the week</th>
+    </tr>
+    <tr align="center">
+        <td><b>Monday</b></td>
+        <td><b>Tuesday</b></td>
+        <td><b>Wednesday</b></td>
+        <td><b>Thursday</b></td>
+        <td><b>Friday</b></td>
+    </tr>
+    <tr align="center">
+        <td>8:00</td>
+        <td rowspan=2>Statistics<br><p style="font-size: 9pt">8:30-10:00<br>Online</p></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>9:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>10:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>11:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>12:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>13:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>14:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>15:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>16:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>17:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>18:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr align="center">
+        <td>19:00</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+    </tr>
+</table>

--- a/30786/resources/_index.md
+++ b/30786/resources/_index.md
@@ -1,0 +1,6 @@
+---
+title: 📚 Courses
+bookFlatSection: true
+weight: 2
+bookHidden: false
+---

--- a/30786/resources/calendar.md
+++ b/30786/resources/calendar.md
@@ -1,0 +1,53 @@
+---
+title: Calendar for A.Y. 2024/25
+weight: 1
+---
+
+# Calendar of the academic year 2024/25
+
+The calendar can be also seen from the [official department's page](https://web.uniroma1.it/i3s/node/7334).
+
+<table>
+    <tr>
+        <th>From...</th>
+        <th>...to</th>
+        <th>What</th>
+    </tr>
+    <tr>
+        <td>23/9/2024 (Monday)</td>
+        <td>20/12/2024 (Friday)</td>
+        <td>1st Semester of lectures<br>
+            <ul>
+                <li><a href="first-year/#first-semester">1st Year Schedule</a></li>
+                <li><a href="second-year/#first-semester">2nd Year Schedule</a></li>
+                <li><a href="third-year/#first-semester">3rd Year Schedule</a></li>
+            </ul>
+        </td>
+    </tr>
+    <tr>
+        <td>7/1/2025 (Tuesday)</td>
+        <td>25/2/2025 (Tuesday)</td>
+        <td>Winter Exam Session</td>
+    </tr>
+    <tr>
+        <td>26/2/2025 (Wednesday)</td>
+        <td>30/5/2025 (Friday)</td>
+        <td>2nd Semester of lectures<br>
+            <ul>
+                <li><a href="first-year/#second-semester">1st Year Schedule</a></li>
+                <li><a href="second-year/#second-semester">2nd Year Schedule</a></li>
+                <li><a href="third-year/#second-semester">3rd Year Schedule</a></li>
+            </ul>
+        </td>
+    </tr>
+    <tr>
+        <td>3/6/2025 (Tuesday)</td>
+        <td>25/7/2025 (Friday)</td>
+        <td>Summer Exam Session</td>
+    </tr>
+    <tr>
+        <td>1/9/2025 (Monday)</td>
+        <td>23/9/2025 (Tuesday)</td>
+        <td>Semptember Exam Session</td>
+    </tr>
+</table>


### PR DESCRIPTION
Addition of various pages to the ACSAI section:
- `docs/exams`: page explaining various details regarding the exams (how to book them, how they work, etc...);
- `docs/opis`: WIP page on how OPIS work, what they are, etc...;
- `docs/getting-in/`: WIP section for getting into ACSAI;
- `docs/news`: a news section to be automatized in a blog-like way.

Started adding pages for each subject (still WIP)