### PR TITLE
Dockerfile: arm64 native support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,16 +15,31 @@ RUN apt-get update && apt-get install -y \
 
 # Installa Hugo
 ENV HUGO_VERSION 0.126.0
-RUN wget -O /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-    && dpkg -i /tmp/hugo.deb \
-    && rm /tmp/hugo.deb
+
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        wget -O /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb; \
+    elif [ "$ARCH" = "aarch64" ]; then \
+        wget -O /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-arm64.deb; \
+    else \
+        echo "Unsupported architecture: $ARCH"; exit 1; \
+    fi && \
+    dpkg -i /tmp/hugo.deb && \
+    rm /tmp/hugo.deb
 
 # Installa Dart Sass
-RUN curl -L https://github.com/sass/dart-sass/releases/download/1.56.1/dart-sass-1.56.1-linux-x64.tar.gz -o dart-sass.tar.gz \
-    && tar -xzf dart-sass.tar.gz \
-    && mv dart-sass /usr/local/bin/ \
-    && ln -s /usr/local/bin/dart-sass/sass /usr/local/bin/sass \
-    && rm dart-sass.tar.gz
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        curl -L https://github.com/sass/dart-sass/releases/download/1.56.1/dart-sass-1.56.1-linux-x64.tar.gz -o dart-sass.tar.gz; \
+    elif [ "$ARCH" = "aarch64" ]; then \
+        curl -L https://github.com/sass/dart-sass/releases/download/1.56.1/dart-sass-1.56.1-linux-arm64.tar.gz -o dart-sass.tar.gz; \
+    else \
+        echo "Unsupported architecture: $ARCH"; exit 1; \
+    fi && \
+    tar -xzf dart-sass.tar.gz && \
+    mv dart-sass /usr/local/bin/ && \
+    ln -s /usr/local/bin/dart-sass/sass /usr/local/bin/sass && \
+    rm dart-sass.tar.gz
 
 # Configura Git per considerare /app come una directory sicura
 RUN git config --global --add safe.directory /app


### PR DESCRIPTION
The Dockerfile now automatically downloads the arm64 version of Hugo and Dart Sass, so as to improve compatibility with arm64 host systems such as macOS on Apple Silicon.