### PR TITLE
Addition of `contacts` page + Minor fixes

### DIFF
--- a/30786/contributing/contacts.md
+++ b/30786/contributing/contacts.md
@@ -6,15 +6,64 @@ weight: 2
 ---
 
 <style>
-.curator {
-    background-color: #5d656a30;
-    width: 90%;
-    height: 350px;
-    border-radius: 8px;
+
+.curatorList {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    margin-top: 50px
+}
+
+@media screen and (minx-width: 100px) {
+    .curator {
+        background-color: #5d656a30;
+        width: 80%;
+        height: 350px;
+        border-radius: 8px;
+        margin: 50px 10px 10px 10px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 5px;
+    }
+}
+
+@media screen and (min-width: 520px) {
+    .curator {
+        background-color: #5d656a30;
+        width: 45%;
+        height: 350px;
+        border-radius: 8px;
+        margin: 50px 10px 10px 10px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .curBadges {
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+        flex-wrap: wrap;
+        font-size: 15px
+    }
+}
+
+@media screen and (min-width: 720px) {
+    .curator {
+        background-color: #5d656a30;
+        width: 30%;
+        height: 350px;
+        border-radius: 8px;
+        margin: 50px 10px 10px 10px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
 }
 
 .curPic {
-    width: 60%;
+    width: 50%;
     border-radius: 128px;
     margin-top: -40px;
     border: 3.5px solid #dedede;
@@ -22,7 +71,12 @@ weight: 2
 
 .curTitle {
     font-size: 1.5em;
-    margin-top: -4px;
+    margin-top: 2px;
+}
+
+.curSubtitle {
+    font-size: 1.2em;
+    margin-top: -200px;
 }
 
 .curBadge {
@@ -70,67 +124,51 @@ weight: 2
 <!-- - **[Michele Palma](https://github.com/palmaaaa):** Computer Science student, Tutor of the Computer Science Didactic Area Council ("CAD"), content curator and code developer; -->
 <!-- - **[Marcello Galisai](https://github.com/marcellogalisai):** student of [Philosophy and Artificial Intelligence](https://corsidilaurea.uniroma1.it/en/corso/2023/31774/home), Tutor of the Computer Science Didactic Area Council ("CAD"), content curator; -->
 
-{{< curators >}}
+<div class="curatorList">
 
 <div class="curator">
-<img src="https://www.github.com/Lorenzoantonelli.png" class="curPic">
-<p class="curTitle"><b>Lorenzo Antonelli</b><p>
-
-<div class="curBadges">
-    <div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> CS</div>
-    <div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div>
-    <div class="curBadge curContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div>
-    <div class="curBadge curCodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div>
+    <img src="https://www.github.com/Lorenzoantonelli.png" class="curPic">
+    <p class="curTitle"><b>Lorenzo Antonelli</b><p>
+    <div class="curBadges">
+        <div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> CS</div>
+        <div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div>
+        <div class="curBadge curContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div>
+        <div class="curBadge curCodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div>
+    </div>
 </div>
-</div>
-
-<--->
 
 <div class="curator">
-<img src="https://www.github.com/ElBi21.png" class="curPic">
-<p class="curTitle"><b>Leonardo Biason</b><p>
-
-<div class="curBadges">
-    <div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> ACSAI</div>
-    <div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div>
-    <div class="curBadge curContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div>
-    <div class="curBadge curCodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div>
+    <img src="https://www.github.com/ElBi21.png" class="curPic">
+    <p class="curTitle"><b>Leonardo Biason</b><p>
+    <div class="curBadges">
+        <div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> ACSAI</div>
+        <div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div>
+        <div class="curBadge curContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div>
+        <div class="curBadge curCodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div>
+    </div>
 </div>
-</div>
-
-<--->
 
 <div class="curator">
-<img src="https://www.github.com/matypist.png" class="curPic">
-<p class="curTitle"><b>Matteo Collica</b><p>
-
-<div class="curBadges">
-    <div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> Informatica</div>
-    <!--<div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div>-->
-    <div class="curBadge curContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div>
-    <div class="curBadge curCodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div>
-    <div class="curBadge curCADRepr"><i class="fa-solid fa-bolt" style="color: #feffff;"></i> Students Representative</div>
+    <img src="https://www.github.com/matypist.png" class="curPic">
+    <p class="curTitle"><b>Matteo Collica</b><p>
+    <div class="curBadges">
+        <div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> Informatica</div>
+        <!--<div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div>-->
+        <div class="curBadge curContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div>
+        <div class="curBadge curCodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div>
+        <div class="curBadge curCADRepr"><i class="fa-solid fa-bolt" style="color: #feffff;"></i> Students Representative</div>
+    </div>
 </div>
-</div>
-
-{{< /curators >}}
-
-{{< curators >}}
-
-<--->
 
 <div class="curator">
-<img src="https://www.github.com/CuriousCI.png" class="curPic">
-<p class="curTitle"><b>Ionut Cicio</b><p>
-
-<div class="curBadges">
-    <div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> CS</div>
-    <div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div>
-    <div class="curBadge curContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div>
-    <div class="curBadge curCodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div>
+    <img src="https://www.github.com/CuriousCI.png" class="curPic">
+    <p class="curTitle"><b>Ionut Cicio</b><p>
+    <div class="curBadges">
+        <div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> CS</div>
+        <div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div>
+        <div class="curBadge curContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div>
+        <div class="curBadge curCodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div>
+    </div>
 </div>
+
 </div>
-
-<--->
-
-{{< /curators >}}

--- a/30786/contributing/contacts.md
+++ b/30786/contributing/contacts.md
@@ -4,6 +4,63 @@ aliases: ["/contacts", "/en/contribute/project-curators"]
 bookToC: false
 weight: 2
 ---
+
+<style>
+.curator {
+    background-color: #5d656a30;
+    width: 90%;
+    height: 350px;
+    border-radius: 8px;
+}
+
+.curPic {
+    width: 60%;
+    border-radius: 128px;
+    margin-top: -40px;
+    border: 3.5px solid #dedede;
+}
+
+.curTitle {
+    font-size: 1.5em;
+    margin-top: -4px;
+}
+
+.curBadge {
+    width: max-content;
+    border-radius: 8px;
+    padding: 1px 6px 1px 6px;
+    margin: 4px;
+}
+
+.curCourse {
+    background-color: #a42a2e;
+}
+
+.curTutor {
+    background-color: #2a69a4;
+}
+
+.curContCur {
+    background-color: #cf8132;
+}
+
+.curCodeDev {
+    background-color: #4d9065;
+}
+
+.curCADRepr {
+    background-color: #8332cf;
+}
+
+.curBadges {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+</style>
+
 # Project Curators
 
 - **[Lorenzo Antonelli](https://github.com/Lorenzoantonelli):** Computer Science student, Tutor of the Computer Science Didactic Area Council ("CAD"), Staff Member of [Sapienza Students Network](https://hub.sapienzastudents.net/), content curator and code developer;
@@ -12,3 +69,68 @@ weight: 2
 - **[Ionut Cicio (CuriousCI)](https://github.com/CuriousCI):** Computer Science student, Tutor of the Computer Science Didactic Area Council ("CAD"), Staff Member of [Sapienza Students Network](https://hub.sapienzastudents.net/), content curator and code developer.
 <!-- - **[Michele Palma](https://github.com/palmaaaa):** Computer Science student, Tutor of the Computer Science Didactic Area Council ("CAD"), content curator and code developer; -->
 <!-- - **[Marcello Galisai](https://github.com/marcellogalisai):** student of [Philosophy and Artificial Intelligence](https://corsidilaurea.uniroma1.it/en/corso/2023/31774/home), Tutor of the Computer Science Didactic Area Council ("CAD"), content curator; -->
+
+{{< curators >}}
+
+<div class="curator">
+<img src="https://www.github.com/Lorenzoantonelli.png" class="curPic">
+<p class="curTitle"><b>Lorenzo Antonelli</b><p>
+
+<div class="curBadges">
+    <div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> CS</div>
+    <div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div>
+    <div class="curBadge curContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div>
+    <div class="curBadge curCodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div>
+</div>
+</div>
+
+<--->
+
+<div class="curator">
+<img src="https://www.github.com/ElBi21.png" class="curPic">
+<p class="curTitle"><b>Leonardo Biason</b><p>
+
+<div class="curBadges">
+    <div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> ACSAI</div>
+    <div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div>
+    <div class="curBadge curContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div>
+    <div class="curBadge curCodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div>
+</div>
+</div>
+
+<--->
+
+<div class="curator">
+<img src="https://www.github.com/matypist.png" class="curPic">
+<p class="curTitle"><b>Matteo Collica</b><p>
+
+<div class="curBadges">
+    <div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> Informatica</div>
+    <!--<div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div>-->
+    <div class="curBadge curContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div>
+    <div class="curBadge curCodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div>
+    <div class="curBadge curCADRepr"><i class="fa-solid fa-bolt" style="color: #feffff;"></i> Students Representative</div>
+</div>
+</div>
+
+{{< /curators >}}
+
+{{< curators >}}
+
+<--->
+
+<div class="curator">
+<img src="https://www.github.com/CuriousCI.png" class="curPic">
+<p class="curTitle"><b>Ionut Cicio</b><p>
+
+<div class="curBadges">
+    <div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> CS</div>
+    <div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div>
+    <div class="curBadge curContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div>
+    <div class="curBadge curCodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div>
+</div>
+</div>
+
+<--->
+
+{{< /curators >}}

--- a/30786/contributing/contacts.md
+++ b/30786/contributing/contacts.md
@@ -1,160 +1,11 @@
 ---
-title: "Contacts"
+title: "Contacts & project curators"
 aliases: ["/contacts", "/en/contribute/project-curators"]
 bookToC: false
 weight: 2
 ---
 
-<style>
-@media screen and (min-width: 100px) {
-    .curatorList {
-        display: flex;
-        flex-direction: column;
-        margin-top: 50px;
-        align-items: center
-    }
-
-    .curator {
-        background-color: #5d656a30;
-        width: 90%;
-        height: 400px;
-        border-radius: 8px;
-        margin: 50px 10px 10px 10px;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        padding: 5px;
-    }
-}
-
-@media screen and (min-width: 520px) {
-    .curatorList {
-        display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
-        margin-top: 50px
-    }
-
-    .curator {
-        background-color: #5d656a30;
-        width: 45%;
-        height: 350px;
-        border-radius: 8px;
-        margin: 50px 10px 10px 10px;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-    }
-
-    .curBadges {
-        display: flex;
-        flex-direction: row;
-        justify-content: center;
-        flex-wrap: wrap;
-        font-size: 15px
-    }
-}
-
-@media screen and (min-width: 720px) {
-    .curatorList {
-        display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
-        margin-top: 50px
-    }
-
-    .curator {
-        background-color: #5d656a30;
-        width: 30%;
-        height: 370px;
-        border-radius: 8px;
-        margin: 50px 10px 10px 10px;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-    }
-}
-
-.curSocials {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    margin-top: -40px
-}
-
-.curSocialIcon {
-    color: #8e9693;
-    margin: 0 15px 0 15px;
-}
-
-.curPic {
-    width: 50%;
-    border-radius: 128px;
-    margin-top: -40px;
-    border: 3.5px solid #dedede;
-}
-
-.curTitle {
-    font-size: 1.5em;
-    margin-top: 2px;
-}
-
-.curSubtitle {
-    font-size: 1.2em;
-    margin-top: -200px;
-}
-
-.curBadge {
-    width: max-content;
-    border-radius: 8px;
-    padding: 1px 6px 1px 6px;
-    margin: 4px;
-}
-
-.curCourse {
-    background-color: #a42a2e;
-}
-
-.curTutor {
-    background-color: #2a69a4;
-}
-
-.curContCur {
-    background-color: #cf8132;
-}
-
-.curCodeDev {
-    background-color: #4d9065;
-}
-
-.curCADRepr {
-    background-color: #8332cf;
-}
-
-.curBadges {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    flex-wrap: wrap;
-}
-
-.separator {
-    width: 98%;
-    height: 1.5px;
-    background-color: #a3a3a3;
-    border-radius: 3px;
-    margin: 25px 0 20px 0;
-}
-</style>
-
-# Project Curators
-
-<!-- - **[Lorenzo Antonelli](https://github.com/Lorenzoantonelli):** Computer Science student, Tutor of the Computer Science Didactic Area Council ("CAD"), Staff Member of [Sapienza Students Network](https://hub.sapienzastudents.net/), content curator and code developer;
-- **[Leonardo Biason (ElBi21)](https://github.com/ElBi21):** Applied Computer Science and Artificial Intelligence student, Tutor of the Computer Science Didactic Area Council ("CAD"), content curator and code developer;
-- **[Matteo Collica (matypist)](https://github.com/matypist):** Computer Science student, Student Representative at the Computer Science Didactic Area Council ("CAD"), Creator and Manager of [Sapienza Students Network](https://hub.sapienzastudents.net/), content curator and code developer;
-- **[Ionut Cicio (CuriousCI)](https://github.com/CuriousCI):** Computer Science student, Tutor of the Computer Science Didactic Area Council ("CAD"), Staff Member of [Sapienza Students Network](https://hub.sapienzastudents.net/), content curator and code developer.
-<!-- - **[Michele Palma](https://github.com/palmaaaa):** Computer Science student, Tutor of the Computer Science Didactic Area Council ("CAD"), content curator and code developer; -->
-<!-- - **[Marcello Galisai](https://github.com/marcellogalisai):** student of [Philosophy and Artificial Intelligence](https://corsidilaurea.uniroma1.it/en/corso/2023/31774/home), Tutor of the Computer Science Didactic Area Council ("CAD"), content curator; -->
+# 🖋 Project Curators
 
 <div class="curatorList">
 
@@ -163,14 +14,14 @@ weight: 2
     <p class="curTitle"><b>Lorenzo Antonelli</b><p>
     <div class="curSocials">
         <a href="https://github.com/Lorenzoantonelli"><i class="fa-brands fa-github curSocialIcon fa-2xl"></i></a>
-        <a href="https://github.com/Lorenzoantonelli"><i class="fa-brands fa-telegram curSocialIcon fa-2xl"></i></a>
+        <a href="https://t.me/lorenzosphotos"><i class="fa-brands fa-telegram curSocialIcon fa-2xl"></i></a>
     </div>
     <div class="separator"></div>
     <div class="curBadges">
-        <div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> CS</div>
-        <div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div>
-        <div class="curBadge curContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div>
-        <div class="curBadge curCodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div>
+        <a href="#anch_curBadge_Course"><div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> CS</div></a>
+        <a href="#anch_curBadge_Tutor"><div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div></a>
+        <a href="#anch_curBadge_ContCur"><div class="curBadge curContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div></a>
+        <a href="#anch_curBadge_CodeDev"><div class="curBadge curCodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div></a>
     </div>
 </div>
 
@@ -183,10 +34,10 @@ weight: 2
     </div>
     <div class="separator"></div>
     <div class="curBadges">
-        <div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> ACSAI</div>
-        <div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div>
-        <div class="curBadge curContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div>
-        <div class="curBadge curCodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div>
+        <a href="#anch_curBadge_Course"><div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> ACSAI</div></a>
+        <a href="#anch_curBadge_Tutor"><div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div></a>
+        <a href="#anch_curBadge_ContCur"><div class="curBadge curContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div></a>
+        <a href="#anch_curBadge_CodeDev"><div class="curBadge curCodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div></a>
     </div>
 </div>
 
@@ -195,15 +46,14 @@ weight: 2
     <p class="curTitle"><b>Matteo Collica</b><p>
     <div class="curSocials">
         <a href="https://github.com/matypist"><i class="fa-brands fa-github curSocialIcon fa-2xl"></i></a>
-        <!--<a href="mailto:leonardo@biason.org"><i class="fa-solid fa-envelope curSocialIcon fa-2xl"></i></a>-->
+        <a href="https://t.me/Matypist"><i class="fa-brands fa-telegram curSocialIcon fa-2xl"></i></a>
     </div>
     <div class="separator"></div>
     <div class="curBadges">
-        <div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> Informatica</div>
-        <!--<div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div>-->
-        <div class="curBadge curContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div>
-        <div class="curBadge curCodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div>
-        <div class="curBadge curCADRepr"><i class="fa-solid fa-bolt" style="color: #feffff;"></i> Students Representative</div>
+        <a href="#anch_curBadge_Course"><div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> Informatica</div></a>
+        <a href="#anch_curBadge_ContCur"><div class="curBadge curContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div></a>
+        <a href="#anch_curBadge_CodeDev"><div class="curBadge curCodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div></a>
+        <a href="#anch_curBadge_CADRepr"><div class="curBadge curCADRepr"><i class="fa-solid fa-bolt" style="color: #feffff;"></i> Students Representative</div></a>
     </div>
 </div>
 
@@ -212,15 +62,39 @@ weight: 2
     <p class="curTitle"><b>Ionut Cicio</b><p>
     <div class="curSocials">
         <a href="https://github.com/CuriousCI"><i class="fa-brands fa-github curSocialIcon fa-2xl"></i></a>
-        <!--<a href="mailto:leonardo@biason.org"><i class="fa-solid fa-envelope curSocialIcon fa-2xl"></i></a>-->
     </div>
     <div class="separator"></div>
     <div class="curBadges">
-        <div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> Informatica</div>
-        <div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div>
-        <div class="curBadge curContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div>
-        <div class="curBadge curCodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div>
+        <a href="#anch_curBadge_Course"><div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> Informatica</div></a>
+        <a href="#anch_curBadge_Tutor"><div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div></a>
+        <a href="#anch_curBadge_ContCur"><div class="curBadge curContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div></a>
+        <a href="#anch_curBadge_CodeDev"><div class="curBadge curCodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div></a>
     </div>
 </div>
 
 </div>
+
+## What do the badges mean?
+
+<table>
+    <tr>
+        <td align="center"><div class="curBadge curCourse" id="anch_curBadge_Course"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> Course</div></td>
+        <td>This badge shows the programme on which the curator currently studies in/studied in while in Sapienza</td>
+    </tr>
+    <tr>
+        <td align="center"><div class="curBadge curTutor" id="anch_curBadge_Tutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div></td>
+        <td>This badge shows that the curator is/has been a tutor for the Computer Science department (DI)</td>
+    </tr>
+    <tr>
+        <td align="center"><div class="curBadge curContCur" id="anch_curBadge_ContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div></td>
+        <td>This badge shows that the curator composes/componed content for the site</td>
+    </tr>
+    <tr>
+        <td align="center"><div class="curBadge curCodeDev" id="anch_curBadge_CodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div></td>
+        <td>This badge shows that the curator developes/developed the code for the site</td>
+    </tr>
+    <tr>
+        <td align="center"><div class="curBadge curCADRepr" id="anch_curBadge_CADRepr"><i class="fa-solid fa-bolt" style="color: #feffff;"></i> Students Representative</div></td>
+        <td>This badge shows that the curator is a students representative for the Computer Science department</td>
+    </tr>
+</table>

--- a/30786/contributing/contacts.md
+++ b/30786/contributing/contacts.md
@@ -6,19 +6,18 @@ weight: 2
 ---
 
 <style>
+@media screen and (min-width: 100px) {
+    .curatorList {
+        display: flex;
+        flex-direction: column;
+        margin-top: 50px;
+        align-items: center
+    }
 
-.curatorList {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    margin-top: 50px
-}
-
-@media screen and (minx-width: 100px) {
     .curator {
         background-color: #5d656a30;
-        width: 80%;
-        height: 350px;
+        width: 90%;
+        height: 400px;
         border-radius: 8px;
         margin: 50px 10px 10px 10px;
         display: flex;
@@ -29,6 +28,13 @@ weight: 2
 }
 
 @media screen and (min-width: 520px) {
+    .curatorList {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        margin-top: 50px
+    }
+
     .curator {
         background-color: #5d656a30;
         width: 45%;
@@ -50,16 +56,35 @@ weight: 2
 }
 
 @media screen and (min-width: 720px) {
+    .curatorList {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        margin-top: 50px
+    }
+
     .curator {
         background-color: #5d656a30;
         width: 30%;
-        height: 350px;
+        height: 370px;
         border-radius: 8px;
         margin: 50px 10px 10px 10px;
         display: flex;
         flex-direction: column;
         align-items: center;
     }
+}
+
+.curSocials {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-top: -40px
+}
+
+.curSocialIcon {
+    color: #8e9693;
+    margin: 0 15px 0 15px;
 }
 
 .curPic {
@@ -113,11 +138,18 @@ weight: 2
     flex-wrap: wrap;
 }
 
+.separator {
+    width: 98%;
+    height: 1.5px;
+    background-color: #a3a3a3;
+    border-radius: 3px;
+    margin: 25px 0 20px 0;
+}
 </style>
 
 # Project Curators
 
-- **[Lorenzo Antonelli](https://github.com/Lorenzoantonelli):** Computer Science student, Tutor of the Computer Science Didactic Area Council ("CAD"), Staff Member of [Sapienza Students Network](https://hub.sapienzastudents.net/), content curator and code developer;
+<!-- - **[Lorenzo Antonelli](https://github.com/Lorenzoantonelli):** Computer Science student, Tutor of the Computer Science Didactic Area Council ("CAD"), Staff Member of [Sapienza Students Network](https://hub.sapienzastudents.net/), content curator and code developer;
 - **[Leonardo Biason (ElBi21)](https://github.com/ElBi21):** Applied Computer Science and Artificial Intelligence student, Tutor of the Computer Science Didactic Area Council ("CAD"), content curator and code developer;
 - **[Matteo Collica (matypist)](https://github.com/matypist):** Computer Science student, Student Representative at the Computer Science Didactic Area Council ("CAD"), Creator and Manager of [Sapienza Students Network](https://hub.sapienzastudents.net/), content curator and code developer;
 - **[Ionut Cicio (CuriousCI)](https://github.com/CuriousCI):** Computer Science student, Tutor of the Computer Science Didactic Area Council ("CAD"), Staff Member of [Sapienza Students Network](https://hub.sapienzastudents.net/), content curator and code developer.
@@ -129,6 +161,11 @@ weight: 2
 <div class="curator">
     <img src="https://www.github.com/Lorenzoantonelli.png" class="curPic">
     <p class="curTitle"><b>Lorenzo Antonelli</b><p>
+    <div class="curSocials">
+        <a href="https://github.com/Lorenzoantonelli"><i class="fa-brands fa-github curSocialIcon fa-2xl"></i></a>
+        <a href="https://github.com/Lorenzoantonelli"><i class="fa-brands fa-telegram curSocialIcon fa-2xl"></i></a>
+    </div>
+    <div class="separator"></div>
     <div class="curBadges">
         <div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> CS</div>
         <div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div>
@@ -140,6 +177,11 @@ weight: 2
 <div class="curator">
     <img src="https://www.github.com/ElBi21.png" class="curPic">
     <p class="curTitle"><b>Leonardo Biason</b><p>
+    <div class="curSocials">
+        <a href="https://github.com/ElBi21"><i class="fa-brands fa-github curSocialIcon fa-2xl"></i></a>
+        <a href="mailto:leonardo@biason.org"><i class="fa-solid fa-envelope curSocialIcon fa-2xl"></i></a>
+    </div>
+    <div class="separator"></div>
     <div class="curBadges">
         <div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> ACSAI</div>
         <div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div>
@@ -151,6 +193,11 @@ weight: 2
 <div class="curator">
     <img src="https://www.github.com/matypist.png" class="curPic">
     <p class="curTitle"><b>Matteo Collica</b><p>
+    <div class="curSocials">
+        <a href="https://github.com/matypist"><i class="fa-brands fa-github curSocialIcon fa-2xl"></i></a>
+        <!--<a href="mailto:leonardo@biason.org"><i class="fa-solid fa-envelope curSocialIcon fa-2xl"></i></a>-->
+    </div>
+    <div class="separator"></div>
     <div class="curBadges">
         <div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> Informatica</div>
         <!--<div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div>-->
@@ -163,8 +210,13 @@ weight: 2
 <div class="curator">
     <img src="https://www.github.com/CuriousCI.png" class="curPic">
     <p class="curTitle"><b>Ionut Cicio</b><p>
+    <div class="curSocials">
+        <a href="https://github.com/CuriousCI"><i class="fa-brands fa-github curSocialIcon fa-2xl"></i></a>
+        <!--<a href="mailto:leonardo@biason.org"><i class="fa-solid fa-envelope curSocialIcon fa-2xl"></i></a>-->
+    </div>
+    <div class="separator"></div>
     <div class="curBadges">
-        <div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> CS</div>
+        <div class="curBadge curCourse"><i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> Informatica</div>
         <div class="curBadge curTutor"><i class="fa-solid fa-person-chalkboard"></i> Tutor for DI</div>
         <div class="curBadge curContCur"><i class="fa-solid fa-scroll" style="color: #feffff;"></i> Content Curator</div>
         <div class="curBadge curCodeDev"><i class="fa-solid fa-code" style="color: #feffff;"></i> Code Developer</div>

--- a/30786/contributing/how-to-contribute.md
+++ b/30786/contributing/how-to-contribute.md
@@ -27,7 +27,7 @@ In order to contribute to the development of the site, you must create a **fork*
 
 1. On GitHub, open the [**repository page of the site**](https://github.com/sapienzastudentsnetwork/sapienzastudentsnetwork.github.io) and create a fork via the button on the top right. You can call it however you want, it won't impact the original repo;
 2. Once your fork finished being created, you have to **clone it locally**. Before actually cloning it, you must copy the address of the repository: on the page of the fork that you just created, click on the green "**<i class="fa-solid fa-code" style="color: #63E6BE;"></i> Code**" button that you can find on the top of the page, and copy the `https` URL that should end in `.git` from the newly opened pop-up;
-3. Open a terminal and navigate on a folder where you want to clone the fork. Once you decided a folder, type `git clone` and then paste your URL after the command. You'll see something like:
+3. Open a terminal and navigate on a folder where you want to clone the fork. Once you decided a folder, type `git clone --recurse-submodules` and then paste your URL after the command. You'll see something like:
 ```bash
 git clone --recurse-submodules https://github.com/<your_username>/<fork_name>.git
 ```

--- a/30786/posts/001_new_ay.md
+++ b/30786/posts/001_new_ay.md
@@ -4,8 +4,9 @@ date: 2024-07-08
 categories:
     - A.Y. 2024/25
     - Calendar
-_build:
-    list: never
 ---
+
+<!--_build:
+    list: never-->
 
 A new academic year is approaching, and the new dates of our department have been just published!

--- a/30786/posts/_index.md
+++ b/30786/posts/_index.md
@@ -1,7 +1,7 @@
 ---
 title: News
-bookFlatSection: true
+# bookFlatSection: true
 weight: 1
-_build:
-    list: never
+# _build:
+#    list: never
 ---

--- a/assets/_curators.scss
+++ b/assets/_curators.scss
@@ -58,7 +58,7 @@
     .curator {
         background-color: #5d656a30;
         width: 30%;
-        height: 350px;
+        height: 370px;
         border-radius: 8px;
         margin: 50px 10px 10px 10px;
         display: flex;
@@ -68,7 +68,15 @@
 }
 
 .curSocials {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-top: -40px
+}
 
+.curSocialIcon {
+    color: #8e9693;
+    margin: 0 15px 0 15px;
 }
 
 .curPic {
@@ -93,6 +101,8 @@
     border-radius: 8px;
     padding: 1px 6px 1px 6px;
     margin: 4px;
+    text-decoration: none;
+    color: #e9ecef;
 }
 
 .curCourse {
@@ -120,4 +130,12 @@
     flex-direction: row;
     justify-content: center;
     flex-wrap: wrap;
+}
+
+.separator {
+    width: 98%;
+    height: 1.5px;
+    background-color: #a3a3a3;
+    border-radius: 3px;
+    margin: 25px 0 20px 0;
 }

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -1,0 +1,1 @@
+@import "curators";

--- a/hugo.toml
+++ b/hugo.toml
@@ -3,6 +3,7 @@ theme = 'hugo-book'
 defaultContentLanguage = 'it'
 defaultContentLanguageInSubdir = true
 enableGitInfo = true
+custom_css = ["css/contributors.css"]
 
 [languages]
     [languages.it]

--- a/it/contribuire/come-contribuire.md
+++ b/it/contribuire/come-contribuire.md
@@ -27,7 +27,7 @@ Per contribuire allo sviluppo del sito, devi creare un **fork** del progetto e m
 
 1. Su GitHub, apri la [**repository del sito**](https://github.com/sapienzastudentsnetwork/sapienzastudentsnetwork.github.io) e crea un fork tramite il pulsante in alto a destra. Puoi chiamarlo come vuoi, non influirà sulla repo originale;
 2. Una volta creato il fork, devi **clonarlo in locale**. Prima di clonarlo, devi copiare l'indirizzo del repository: sulla pagina del fork che hai appena creato, clicca sul pulsante verde "**<i class="fa-solid fa-code" style="color: #63E6BE;"></i> Code**" che trovi in alto sulla pagina e copia l'URL `https` che dovrebbe terminare in `.git` dalla finestra pop-up appena aperta;
-3. Apri un terminale e naviga in una cartella dove vuoi clonare il fork. Una volta scelta la cartella, digita `git clone` e poi incolla il tuo URL dopo il comando. Vedrai qualcosa del tipo:
+3. Apri un terminale e naviga in una cartella dove vuoi clonare il fork. Una volta scelta la cartella, digita `git clone --recurse-submodules` e poi incolla il tuo URL dopo il comando. Vedrai qualcosa del tipo:
 ```bash
 git clone --recurse-submodules https://github.com/<tuo_username>/<nome_fork>.git
 ```

--- a/layouts/shortcodes/course.html
+++ b/layouts/shortcodes/course.html
@@ -1,0 +1,11 @@
+<style>
+.curCourse {
+    background-color: #a42a2e;
+    width: 90px;
+    border-radius: 8px;
+}
+</style>
+
+<div class="curCourse" align="left">
+  <i class="fa-solid fa-graduation-cap" style="color: #feffff;"></i> {{ . | $.Page.RenderString }}
+</div>

--- a/layouts/shortcodes/curators.html
+++ b/layouts/shortcodes/curators.html
@@ -1,0 +1,7 @@
+<div class="book-columns flex flex-wrap" style="margin-top: 40px;">
+{{ range split .Inner "<--->" }}
+  <div class="flex-even markdown-inner" align="center">
+    {{ . | $.Page.RenderString }}
+  </div>
+{{ end }}
+</div>

--- a/static/css/contributors.css
+++ b/static/css/contributors.css
@@ -1,0 +1,123 @@
+@media screen and (min-width: 100px) {
+    .curatorList {
+        display: flex;
+        flex-direction: column;
+        margin-top: 50px;
+        align-items: center
+    }
+
+    .curator {
+        background-color: #5d656a30;
+        width: 90%;
+        height: 400px;
+        border-radius: 8px;
+        margin: 50px 10px 10px 10px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 5px;
+    }
+}
+
+@media screen and (min-width: 520px) {
+    .curatorList {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        margin-top: 50px
+    }
+
+    .curator {
+        background-color: #5d656a30;
+        width: 45%;
+        height: 350px;
+        border-radius: 8px;
+        margin: 50px 10px 10px 10px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .curBadges {
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+        flex-wrap: wrap;
+        font-size: 15px
+    }
+}
+
+@media screen and (min-width: 720px) {
+    .curatorList {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        margin-top: 50px
+    }
+
+    .curator {
+        background-color: #5d656a30;
+        width: 30%;
+        height: 350px;
+        border-radius: 8px;
+        margin: 50px 10px 10px 10px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+}
+
+.curSocials {
+
+}
+
+.curPic {
+    width: 50%;
+    border-radius: 128px;
+    margin-top: -40px;
+    border: 3.5px solid #dedede;
+}
+
+.curTitle {
+    font-size: 1.5em;
+    margin-top: 2px;
+}
+
+.curSubtitle {
+    font-size: 1.2em;
+    margin-top: -200px;
+}
+
+.curBadge {
+    width: max-content;
+    border-radius: 8px;
+    padding: 1px 6px 1px 6px;
+    margin: 4px;
+}
+
+.curCourse {
+    background-color: #a42a2e;
+}
+
+.curTutor {
+    background-color: #2a69a4;
+}
+
+.curContCur {
+    background-color: #cf8132;
+}
+
+.curCodeDev {
+    background-color: #4d9065;
+}
+
+.curCADRepr {
+    background-color: #8332cf;
+}
+
+.curBadges {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    flex-wrap: wrap;
+}


### PR DESCRIPTION
- Polished the `contacts` page, which is now fancier and more readable (even on mobile);
- Fixed a typo in the `How to contribute` page where the wasn't the `--recurse-submodules` flag on the `git clone` command;
- Externalized the CSS into an SCSS file (now new SCSS files can be added in the `assets` folder (with the `_file_name.scss` nomenclature) and can be imported in `_custom.scss` by doing `@import "file_name";`.